### PR TITLE
Fix request to handle ClientException in Guzzle > 7

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -228,7 +228,16 @@ class Request
      */
     public function send()
     {
+      try {
         $response = $this->client->request($this->method, $this->endpoint, $this->options);
+      }
+      catch (\Exception $e) {
+        // Guzzle >= 7 throws GuzzleHttp\Exception\ClientException.
+        // Need to catch this exception and throw Okta\Exception instead.
+        throw new Okta\Exception(json_decode($e));
+      }
+
+
 
         $bodyContents = $response->getBody()->getContents();
 


### PR DESCRIPTION
This transposes the Guzzle 7 `ClientException` into an OktaException to allow for compatibility with Guzzle 6 and 7